### PR TITLE
6章6節を修正

### DIFF
--- a/sample_code/6/6-6/sample-6-6-1.playground/Contents.swift
+++ b/sample_code/6/6-6/sample-6-6-1.playground/Contents.swift
@@ -14,13 +14,13 @@ for i in 0..<10 {
 // 0 1 2 3 4 5 6 7 8 9
 
 // 配列の格納数分処理を行う（※B）
-for i in 0..<array.count {
-    print(i)
+for i in array.indices {
+    print(array[i])
 }
 // 0 1 2 3 4 5 6 7 8 9
 
 // 配列の格納数分の処理を行う（※C）
-for i in array {
+array.forEach { i in
     print(i)
 }
 // 0 1 2 3 4 5 6 7 8 9

--- a/sample_code/6/6-6/sample-6-6-2.playground/Contents.swift
+++ b/sample_code/6/6-6/sample-6-6-2.playground/Contents.swift
@@ -12,13 +12,12 @@ for i in (0..<10).reversed() {
 }
 // 9 8 7 6 5 4 3 2 1 0
 
-for i in (0..<array.count).reversed() {
-    print(i)
+for i in array.indices.reversed() {
+    print(array[i])
 }
 // 9 8 7 6 5 4 3 2 1 0
 
-
-for i in array.reversed() {
+array.reversed().forEach { i in
     print(i)
 }
 // 9 8 7 6 5 4 3 2 1 0

--- a/sample_code/6/6-6/sample-6-6-3.playground/Contents.swift
+++ b/sample_code/6/6-6/sample-6-6-3.playground/Contents.swift
@@ -9,8 +9,8 @@ let array: [Int] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 // indexはインデックス、valueはインデックスの順番に格納されている中身です
 // index, valueの箇所の変数名は自由に指定することができます
-for (index, value) in array.enumerated() {
-    print("index: \(index), value:\(value)")
+for (i, value) in zip(array.indices, array) {
+    print("index: \(i), value:\(value)")
 }
 
 /*


### PR DESCRIPTION
## 内容

- 格納数分は  `indices` を使用する
 - 中身ではなくカウントをプリントしている部分を fix
- 格納されているものを取り出すときは `forEach` を使用する
- `index` を同時に取り出ししたいときは `emurated()` ではなく `indices` を使用する
